### PR TITLE
fixed a bug in RandomApply that made the selection bounded to the low…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "torch-trandsforms"
-version = "0.3.2"
+version = "0.3.3"
 description = "A pytorch-first transform library for ND data, such as multi-channel 3D volumes"
 readme = "README.md"
 authors = ["Oliver Hjermitslev <oliver.gyldenberg@alexandra.dk>"]

--- a/torch_trandsforms/shape.py
+++ b/torch_trandsforms/shape.py
@@ -98,9 +98,6 @@ class RandomFlip(KeyedNdTransform):
         return {"dim": torch.randint(0, self.nd, size=(1,)).item()}
 
     def apply(self, input, **params):
-        if input.ndim < self.nd:
-            raise ValueError(f"Input dimensionality {input.ndim} must be greater than or equal to self.nd {self.nd}")
-
         return input.flip(params["dim"])
 
 

--- a/torch_trandsforms/structure.py
+++ b/torch_trandsforms/structure.py
@@ -99,12 +99,12 @@ class RandomApply:
 
         for n in range(int(N)):
             maxsum = sum(probs)
-            cumsum = [sum(probs[:i]) - probs[0] for i in range(1, len(probs))]
+            cumsum = [sum(probs[: i + 1]) for i in range(len(probs))]
 
             p = maxsum * torch.rand((1,)).item()
 
-            for i in range(1, len(cumsum)):  # find where the random value slots in
-                if p >= cumsum[i]:
+            for i in range(len(cumsum)):  # find where the random value slots in
+                if p <= cumsum[i]:
                     inputs = transforms[i](**inputs)
 
                     if not self.allow_same:


### PR DESCRIPTION
Fixed a bug in RandomApply. It should now actually work as cumulative selection.

## Description

RandomApply used to select the first possible, or None, transform in the list rather than increasing vs cumulative selection. It has been changed to select based on < rather than > to actually use cumulative summation and positive indexing.

Also removed some unreachable code in randomflip.

Bumped the patch number to overwrite buggy versions.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/ohjerm/torch-trandsforms/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/ohjerm/torch-trandsforms/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
