### PR TITLE
Fix salt and pepper init bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "torch-trandsforms"
-version = "0.3.3"
+version = "0.3.4"
 description = "A pytorch-first transform library for ND data, such as multi-channel 3D volumes"
 readme = "README.md"
 authors = ["Oliver Hjermitslev <oliver.gyldenberg@alexandra.dk>"]

--- a/tests/test_value.py
+++ b/tests/test_value.py
@@ -59,12 +59,12 @@ def test_normalize(mean, std, nd, input, expected):
     ("prob", "low", "hi", "a", "b", "expected"),
     [
         (None, -1, 1, 0.5, 0.5, AssertionError),
-        (1, "None", 1, 0.5, 0.5, AssertionError),
+        (1, "None", torch.tensor(1), 0.5, 0.5, AssertionError),
         (1, -1, -2, 0.5, 0.5, AssertionError),
         (1, -1, 1, "None", 0.5, AssertionError),
         (1, -1, 1, 0.5, -1, AssertionError),
-        (1, -1, 1, 0.5, 0.5, None),
-        (0.5, -100, 1000, 0.1, 0.9, None),
+        (1, torch.tensor([-1.0] * 4), 1, 0.5, 0.5, None),
+        (0.5, -100, torch.tensor([1000] * 4), 0.1, 0.9, None),
         (100, -100, 1000, 0.9, 0.1, AssertionError),
     ],
 )
@@ -86,9 +86,9 @@ def test_saltandpepper(prob, low, hi, a, b, expected):
         (1, "None", 1, 0.5, 0.5, AssertionError),
         (1, -1, -2, 0.5, 0.5, AssertionError),
         (1, -1, 1, "None", 0.5, AssertionError),
-        (1, -1, 1, 0.5, -1, AssertionError),
-        (1, -1, 1, 0.5, 0.5, None),
-        (0.5, -100, 1000, 0.1, 0.9, None),
+        (1, torch.tensor([-1.0] * 4), 1, 0.5, -1, AssertionError),
+        (1, torch.tensor(-1), 1, 0.5, 0.5, None),
+        (0.5, -100, torch.tensor([1000] * 4), 0.1, 0.9, None),
         (100, -100, 1000, 0.9, 0.1, AssertionError),
     ],
 )

--- a/torch_trandsforms/value.py
+++ b/torch_trandsforms/value.py
@@ -151,9 +151,14 @@ class SaltAndPepperNoise(KeyedNdTransform):
         self.prob = prob
 
         assert isinstance(low, (int, float, torch.Tensor)), f"low must be a number (got {type(low)})"
-        assert (isinstance(hi, (int, float)) and low < hi) or (
-            isinstance(hi, torch.Tensor) and torch.all(low < hi)
-        ), f"hi must be a number greater than low"
+        assert isinstance(hi, (int, float, torch.Tensor)), f"hi must be a number or tensor (got {type(hi)})"
+
+        if isinstance(hi, (int, float)) and isinstance(low, (int, float)):
+            assert low < hi, f"hi ({hi}) must be a number greater than low ({low})"
+        else:
+            diff = low < hi
+            assert isinstance(diff, torch.Tensor), f"this should never run - mypy check"
+            assert torch.all(diff), f"hi ({hi}) must be a number greater than low ({low})"
 
         if isinstance(low, torch.Tensor) and low.ndim > 0:
             low = low.view(*low.shape, *[1] * self.nd)


### PR DESCRIPTION
## Description

SaltAndPepperNoise used to fail in some cases of multi-channel tensor low/hi arguments, now should work for all valid instances of int, float, and torch.Tensor (including 0D and multi-channel)

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/ohjerm/torch-trandsforms/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/ohjerm/torch-trandsforms/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
