### PR TITLE
Changed default behaviour of RandomRotate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,3 +26,4 @@
 - [ ] I've updated the code style using `make codestyle`.
 - [ ] I've written tests for all new methods and classes that I created.
 - [ ] I've written the docstring in Google format for all the methods and classes that I used.
+- [ ] I've added any new traNDsforms to the test_speed.py script and run `poetry run python3 test_speed.py`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       run: make poetry-download
 
     - name: Set up cache
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@v4.0.3
       with:
         path: .venv
         key: venv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       run: make poetry-download
 
     - name: Set up cache
-      uses: actions/cache@v4.0.3
+      uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('poetry.lock') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_stages: [commit, push]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.2.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: pyupgrade
-        entry: poetry run pyupgrade --py38-plus
+        entry: poetry run pyupgrade --py310-plus
         types: [python]
         language: system
 

--- a/TIMING.md
+++ b/TIMING.md
@@ -8,23 +8,24 @@ Automatically generated with test_speed.py
 
 **GPU**: NVIDIA GeForce RTX 3050 Ti Laptop GPU
 
-**torch**: 2.2.2+cu121
+**torch**: 2.5.1+cu124
 
-**torchvision**: 0.17.2+cu121
+**torchvision**: 0.20.1+cu124
 
 ### Basic Transforms
 
 | Class | 10x64x64x64 | 10x64x64x64 CUDA | 10x128x128x128 | 10x128x128x128 CUDA |
 |-------|-------------|------------------|----------------|---------------------|
-| RandomRotate90 | 0.0006 | 0.0000 | 0.0087 | 0.0000 |
-| UniformNoise | 0.0146 | 0.0000 | 0.1257 | 0.0000 |
-| Normalize | 0.0008 | 0.0000 | 0.0207 | 0.0000 |
-| SaltAndPepperNoise | 0.0489 | 0.0012 | 0.3371 | 0.0074 |
-| AdditiveBetaNoise | 0.0457 | 0.0015 | 0.3559 | 0.0103 |
-| GaussianNoise | 0.0140 | 0.0012 | 0.1360 | 0.0057 |
-| RandomFlip | 0.0002 | 0.0000 | 0.0087 | 0.0000 |
-| RandomRotate | 0.0434 | 0.0016 | 0.5589 | 0.0115 |
-| RandomPadding | 0.0007 | 0.0000 | 0.0155 | 0.0001 |
+| RandomRotate90 | 0.0006 | 0.0000 | 0.0137 | 0.0000 |
+| UniformNoise | 0.0191 | 0.0000 | 0.1320 | 0.0000 |
+| Normalize | 0.0031 | 0.0000 | 0.0227 | 0.0000 |
+| SaltAndPepperNoise | 0.0426 | 0.0011 | 0.3265 | 0.0068 |
+| AdditiveBetaNoise | 0.0538 | 0.0014 | 0.3501 | 0.0093 |
+| GaussianNoise | 0.0132 | 0.0012 | 0.1423 | 0.0057 |
+| RandomFlip | 0.0002 | 0.0000 | 0.0111 | 0.0000 |
+| RandomRotate | 0.0422 | 0.0018 | 0.4836 | 0.0150 |
+| RandomPadding | 0.0005 | 0.0000 | 0.0186 | 0.0001 |
+| RandomBlock | 0.0001 | 0.0000 | 0.0002 | 0.0000 |
 
 
 ### Block Transforms
@@ -35,7 +36,7 @@ Input size: 10x64x64x64. Testing output sizes:
 
 | Class | 32x32x32 | 64x64x64 | 128x128x128 | 128x128x128 CUDA |
 |-------|----------|----------|-------------|------------------|
-| CenterCrop | 0.0015 | 0.0099 | 0.3787 | 0.1121 |
-| RandomCrop | 0.0035 | 0.0148 | 0.4060 | 0.0776 |
-| Resize | 0.0021 | 0.0055 | 0.0476 | 0.0106 |
-| RandomResize | 0.0015 | 0.0108 | 0.0770 | 0.0002 |
+| CenterCrop | 0.0018 | 0.0150 | 0.4458 | 0.1431 |
+| RandomCrop | 0.0048 | 0.0136 | 0.4218 | 0.1149 |
+| Resize | 0.0017 | 0.0058 | 0.0521 | 0.0005 |
+| RandomResize | 0.0017 | 0.0064 | 0.0524 | 0.0001 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,17 @@ classifiers = [  #! Update me
   "Topic :: Software Development :: Libraries :: Python Modules",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 
 
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 torch = ">= 1.13.1"
 torchvision = ">= 0.14.0"
 
@@ -57,7 +58,7 @@ pytest-cov = "^4.1.0"
 
 [tool.black]
 # https://github.com/psf/black
-target-version = ["py38", "py39", "py310"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 line-length = 140
 color = true
 
@@ -79,7 +80,7 @@ exclude = '''
 
 [tool.isort]
 # https://github.com/timothycrosley/isort/
-py_version = 38
+py_version = 310
 line_length = 140
 
 known_typing = ["typing", "types", "typing_extensions", "mypy", "mypy_extensions"]
@@ -92,7 +93,7 @@ color_output = true
 
 [tool.mypy]
 # https://mypy.readthedocs.io/en/latest/config_file.html#using-a-pyproject-toml-file
-python_version = 3.8
+python_version = "3.10"
 pretty = true
 show_traceback = true
 color_output = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [  #! Update me
 python = "^3.8"
 torch = ">= 1.13.1"
 torchvision = ">= 0.14.0"
+virtualenv = "^20.29.3"
 
 [tool.poetry.dev-dependencies]
 bandit = "^1.7.1"

--- a/test_speed.py
+++ b/test_speed.py
@@ -6,7 +6,7 @@ import torchvision
 
 from torch_trandsforms.rotation import RandomRotate, RandomRotate90
 from torch_trandsforms.shape import CenterCrop, RandomCrop, RandomFlip, RandomPadding, RandomResize, Resize
-from torch_trandsforms.value import AdditiveBetaNoise, GaussianNoise, Normalize, SaltAndPepperNoise, UniformNoise
+from torch_trandsforms.value import AdditiveBetaNoise, GaussianNoise, Normalize, RandomBlock, SaltAndPepperNoise, UniformNoise
 
 
 def write_file_head(file):
@@ -144,6 +144,7 @@ def main():
         RandomFlip,
         RandomRotate,
         RandomPadding,
+        RandomBlock,
     ]
     block_classes = [CenterCrop, RandomCrop, Resize, RandomResize]
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -5,7 +5,8 @@ import numpy
 import pytest
 import torch
 
-from torch_trandsforms._functional import crop, pad, rotate
+from torch_trandsforms._functional import affine_grid_sampling, crop, pad, rotate
+from torch_trandsforms._utils import get_affine_matrix, get_output_size, get_rot_3d
 
 
 @pytest.mark.parametrize(
@@ -56,20 +57,61 @@ def test_crop(pos, size, pad, expected):
 
 
 @pytest.mark.parametrize(
-    ("input_shape", "angle", "out_size", "sample_mode", "padding_mode", "align_corners", "expected"),
+    ("input_shape", "angle", "out_size", "mode", "sample_mode", "padding_mode", "align_corners", "expected"),
     [
-        ((1, 3, 4, 4), 90, None, "nearest", "zeros", True, None),
-        ((10, 10, 24, 24, 24), [45, 0, 42], (10, 10, 12, 12, 12), "bilinear", "reflection", False, None),
-        ((4, 5, 6), 7, (4, 5, 6), "nearest", "zeros", False, NotImplementedError),
-        ((1, 4, 5, 6), 7, None, "nearest", "zeros", False, None),
-        ((1, 3, 24, 24, 24, 24), [6, 7, 8, 9, 10, 11], None, "nearest", "zeros", True, NotImplementedError),
-        ((1, 3, 24, 24, 24), [10, 20], None, "nearest", "zeros", True, NotImplementedError),
+        ((1, 3, 4, 4), 90, None, "crop", "nearest", "zeros", True, None),
+        ((10, 10, 24, 24, 24), [45, 0, 42], (10, 10, 12, 12, 12), "nothing", "bilinear", "reflection", False, None),
+        ((4, 5, 6), 7, (4, 5, 6), "nothing", "nearest", "zeros", False, NotImplementedError),
+        ((1, 4, 5, 6), 7, None, "nothing", "nearest", "zeros", False, None),
+        ((1, 3, 24, 24, 24, 24), [6, 7, 8, 9, 10, 11], None, "crop", "nearest", "zeros", True, NotImplementedError),
+        ((1, 3, 24, 24, 24), [10, 20], None, "nothing", "nearest", "zeros", True, NotImplementedError),
     ],
 )
-def test_rotate(input_shape, angle, out_size, sample_mode, padding_mode, align_corners, expected):
+def test_rotate(input_shape, angle, out_size, mode, sample_mode, padding_mode, align_corners, expected):
     with pytest.raises(expected) if expected is not None else nullcontext():
         tensor = torch.arange(prod(input_shape), dtype=torch.float).view(*input_shape)
         if out_size is None:
             out_size = input_shape
-        result = rotate(tensor, angle, out_size, sample_mode, padding_mode, align_corners)
+        result = rotate(tensor, angle, out_size, mode, sample_mode, padding_mode, align_corners)
         assert result.shape == out_size
+
+
+@pytest.mark.parametrize(
+    ("input_shape", "angle", "translation", "mode"),
+    [
+        ((1, 1, 6, 8, 6), [0, 90, 90], [0, 0, 0], "crop"),
+        ((1, 1, 6, 6, 9), [90, 0, 90], [0, 0, 0], "minpad"),
+        ((1, 1, 6, 6, 6), [90, 90, 0], [0, 0, 0], "maxpad"),
+        ((1, 1, 4, 4, 6), [90, 90, 90], [0, 0, 0], "nothing"),
+        ((1, 1, 6, 6, 8), [0, 45, 45], [0, 0, 0], "crop"),
+        ((1, 1, 6, 9, 6), [45, 0, 45], [0, 0, 0], "minpad"),
+        ((1, 1, 6, 6, 4), [45, 45, 0], [0, 0, 0], "maxpad"),
+        ((1, 1, 6, 6, 6), [45, 45, 45], [0, 0, 0], "nothing"),
+        ((1, 1, 9, 9, 9), [45, 45, 0], [-1, 3, 0], "crop"),
+        ((1, 1, 6, 6, 6), [45, 0, 45], [-1, 0, 0], "minpad"),
+        ((1, 1, 6, 6, 4), [0, 45, 45], [0, 0, -4], "maxpad"),
+        ((1, 1, 6, 6, 6), [45, 45, 45], [1, 0, 0], "nothing"),
+        ((1, 1, 6, 6, 6), [0, 0, 0], [1, 2, 3], "cheese melt"),
+    ],
+)
+def test_affine_grid_sampling(input_shape, angle, translation, mode):
+    from warnings import warn
+
+    rots = get_rot_3d(angle)
+    mat = get_affine_matrix(rots, torch.tensor(translation).unsqueeze(-1), 3)
+    max_size = [1, 1, *get_output_size(input_shape[-3:], mat, round=True)]
+
+    with pytest.raises(ValueError) if mode == "cheese melt" else nullcontext():
+        size = max_size if mode != "cheese melt" else None
+        sampled = affine_grid_sampling(torch.rand(input_shape), theta=mat, size=input_shape, mode=mode)
+
+        if mode in ("crop", "nothing"):
+            assert torch.equal(torch.tensor(sampled.shape), torch.tensor(input_shape))
+        elif mode == "minpad":
+            assert torch.equal(torch.tensor(sampled.shape), torch.tensor(max_size))
+        elif mode == "maxpad":
+            mx = torch.tensor(size[-3:]).max()  # type: ignore
+            cubed_shape = torch.tensor([1, 1, mx, mx, mx])
+            assert torch.equal(torch.tensor(sampled.shape), cubed_shape)
+        else:
+            raise ValueError("test mode failed")

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -52,7 +52,7 @@ def test_rotate90(nd, expected):
 def test_rotate(input_shape, nd, rotation, keys, expected):
     """Test RandomRotate"""
     with pytest.raises(expected) if expected is not None else nullcontext():
-        rotator = RandomRotate(rotation, nd=nd, keys=keys, align_corners=True)
+        rotator = RandomRotate(rotation, nd=nd, keys=keys, align_corners=True, p=1.0)
 
         foo = torch.arange(prod(input_shape)).view(*input_shape).float()
         bar = torch.arange(prod(input_shape)).view(*input_shape).float()

--- a/torch_trandsforms/_functional.py
+++ b/torch_trandsforms/_functional.py
@@ -5,7 +5,7 @@ from numbers import Number
 import torch
 import torch.nn.functional as t_F
 
-from ._utils import get_affine_matrix, get_rot_2d, get_rot_3d, get_tensor_sequence
+from ._utils import get_affine_matrix, get_output_size, get_rot_2d, get_rot_3d, get_tensor_sequence
 
 
 def pad(x, padding, value=0.0):
@@ -185,7 +185,7 @@ def crop(x, pos, size, padding=None):
     return padded_x
 
 
-def affine_grid_sampling(input, theta, size=None, sample_mode="bilinear", padding_mode="zeros", align_corners=None):
+def affine_grid_sampling(input, theta, size=None, mode="nothing", sample_mode="bilinear", padding_mode="zeros", align_corners=None):
     """
     Placeholder for generating flow fields and grid sampling in one
     TODO: align_corners automatic decision if None
@@ -198,22 +198,68 @@ def affine_grid_sampling(input, theta, size=None, sample_mode="bilinear", paddin
     Args:
         input (torch.Tensor): The input tensor to transform
         theta (torch.Tensor): Batch of affine matrices
-        size (torch.Size): The output size
+        size (Optional[torch.Size]): The output size. Default is None, which returns the input's size
+        mode (str): The affine grid sampling mode - choose between crop (returns original size), minpad (returns minimum size that fits entire transformation), maxpax (returns the maximum size used to make linear transformation), or nothing (default, returns an actual affine transformation)
         sample_mode (str): See https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html `mode` for information on sampling. (default: bilinear)
         padding_mode (str): See https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html `padding_mode` for information on padding. (default: zeros)
         align_corners (bool): Whether to consider the edge pixel or its center the input's -1,1 extents. If None (default) will
 
     Returns:
         torch.tensor: The grid-sampled input, as determined by theta (the affine transformation matrix).
+
+    Raises:
+        ValueError: If the `mode` argument is not one of crop, minpad, maxpax, or nothing
     """
 
     if theta.ndim < 3 or theta.shape[0] == 1:
         theta = torch.broadcast_to(theta, (input.shape[0], *theta.shape[-2:]))
-    grid = t_F.affine_grid(theta, size or input.Size(), align_corners=align_corners).to(input.device)
-    return t_F.grid_sample(input, grid, mode=sample_mode, padding_mode=padding_mode, align_corners=align_corners)
+
+    if size is None:
+        size = input.shape
+
+    if mode in ("crop", "minpad", "maxpad"):
+        trailing = theta.shape[1]
+        inshape = input.shape[-trailing:]
+
+        output_size = get_output_size(inshape, theta, round=True)
+        max_size = output_size.max()
+
+        trailing_max = [max_size] * trailing
+        size = (*input.shape[:-trailing], *trailing_max)
+
+        grid = torch.empty(1, *trailing_max, trailing + 1, dtype=input.dtype, device=input.device)
+        for dim, steps in enumerate(trailing_max[::-1]):
+            space = torch.linspace(-max_size * 0.5 + 0.5, max_size * 0.5 - 0.5, steps=steps, device=input.device)
+            for _ in range(dim):
+                space = space.unsqueeze(-1)
+            grid[..., dim].copy_(space)
+        grid[..., -1].fill_(1)
+
+        theta1 = theta.transpose(1, 2) / (0.5 * torch.tensor(inshape[::-1], dtype=input.dtype, device=input.device))
+        grid = grid.view(1, -1, trailing + 1).bmm(theta1).view(1, *trailing_max, trailing)
+        sampled = t_F.grid_sample(input, grid, mode=sample_mode, padding_mode=padding_mode, align_corners=align_corners)
+
+        if mode == "crop":
+            crop_corner = (torch.tensor(size) - torch.tensor(input.shape)) // 2
+            crop_shape = input.shape
+            sampled = crop(sampled, crop_corner, crop_shape, padding=None)
+        elif mode == "minpad":
+            crop_corner = (torch.tensor(size)[-len(output_size) :] - output_size) // 2
+            crop_shape = output_size
+            sampled = crop(sampled, crop_corner, crop_shape, padding=None)
+        elif mode == "maxpad":
+            pass  # no need to crop here, we have the max padding
+
+    elif mode == "nothing":
+        grid = t_F.affine_grid(theta, size, align_corners=align_corners).to(input.device)
+        return t_F.grid_sample(input, grid, mode=sample_mode, padding_mode=padding_mode, align_corners=align_corners)
+    else:
+        raise ValueError(f"mode f{mode} not understood, please choose one of correct, minpad, maxpad, or nothing")
+
+    return sampled
 
 
-def rotate(input, angle, out_size=None, sample_mode="bilinear", padding_mode="zeros", align_corners=None):
+def rotate(input, angle, out_size=None, mode="crop", sample_mode="bilinear", padding_mode="zeros", align_corners=None):
     """
     Uses torch grid_sample to rotate spatial and volumetric data
     Currently not implemented for >3D (TODO: Implement ND grid sampling)
@@ -222,6 +268,7 @@ def rotate(input, angle, out_size=None, sample_mode="bilinear", padding_mode="ze
         input (torch.Tensor): input tensor to rotate
         angle (float or sequence of float): angle(s) to rotate the input in trailing order
         out_size (Optional[sequence]): The output size. If None, uses input.size() to determine the output size
+        mode (str): The affine grid sampling mode - choose between crop (returns original size), minpad (returns minimum size that fits entire transformation), maxpax (returns the maximum size used to make linear transformation), or nothing (returns an actual affine transformation, likely unwanted in rotation)
         sample_mode (str): See https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html `mode` for information on sampling. (default: bilinear)
         padding_mode (str): See https://pytorch.org/docs/stable/generated/torch.nn.functional.grid_sample.html `padding_mode` for information on padding. (default: zeros)
         align_corners (bool): Whether to consider the edge pixel or its center the input's -1,1 extents. If None (default) will
@@ -251,5 +298,5 @@ def rotate(input, angle, out_size=None, sample_mode="bilinear", padding_mode="ze
         raise NotImplementedError(f"Rotation for len(angle) = {len(angle)} is not implemented")
 
     return affine_grid_sampling(
-        input, theta, out_size or input.size(), sample_mode=sample_mode, padding_mode=padding_mode, align_corners=align_corners
+        input, theta, out_size, mode=mode, sample_mode=sample_mode, padding_mode=padding_mode, align_corners=align_corners
     )

--- a/torch_trandsforms/_utils.py
+++ b/torch_trandsforms/_utils.py
@@ -1,7 +1,7 @@
 """Utility functions"""
 
-from typing import Sequence
-
+from collections.abc import Sequence
+from itertools import product
 from numbers import Number
 
 import numpy
@@ -165,3 +165,37 @@ def get_affine_matrix(rotation=None, translation=None, nd=None):
         translation = torch.zeros(rotation.shape[-2]).view(-1, 1)
 
     return torch.cat([rotation, translation], dim=-1)
+
+
+def get_output_size(shape, theta, round=False):
+    """
+    Calculate a theoretical output size for a certain shape given the transformation theta
+
+    Args:
+        shape (iterable, torch.Tensor, numpy.ndarray): Size of the data to be transformed
+        theta (torch.tensor): Transformation matrix
+        round (bool): Default false. Whether to return the precise size of the expanded output or the rounded long version
+
+    Returns:
+        torch.Tensor: the minimum size of the data to fit the entire transformation
+    """
+    if not isinstance(shape, torch.Tensor):
+        shape = torch.tensor(shape, dtype=theta.dtype, device=theta.device)
+
+    points = torch.tensor(list(product(*[[-0.5, 0.5] for _ in range(len(shape))], [1])), dtype=theta.dtype, device=theta.device)
+    points[..., :-1] *= shape
+
+    transformed_points = torch.matmul(points, theta.transpose(-1, -2))  # matmul the maximum points
+    mins, _ = transformed_points.squeeze().min(dim=0)
+    maxs, _ = transformed_points.squeeze().max(dim=0)
+
+    if round:
+        # this is a hack, sorry - it only works with 1e-4 afaics
+        # it is implemented to avoid float precision inaccuracies
+        # optimally, the calculation is something like
+        #   (maxs - mins).ceil().long(),
+        #   but this also produces errors in some circumstances where both the 1 and -1 indexed grid holds information
+        mins = ((mins / 1e-4).trunc_() * 1e-4).floor().long()
+        maxs = ((maxs / 1e-4).trunc_() * 1e-4).ceil().long()
+
+    return maxs - mins

--- a/torch_trandsforms/rotation.py
+++ b/torch_trandsforms/rotation.py
@@ -74,9 +74,16 @@ class RandomRotate(KeyedNdTransform):
     """
     Applies a random rotation in the trailing `nd` axes
     Currently only implemented for `nd` <= 3
+
+    Args:
+        rotation (float, int, iterable, numpy.ndarray, or torch.Tensor): Rotation allowance in each `nd` dimension
+
+    See `torch_trandsforms._functional.rotate` for further arguments
     """
 
-    def __init__(self, rotation, sample_mode="bilinear", padding_mode="zeros", align_corners=None, p=0.5, nd=3, keys="*"):
+    def __init__(
+        self, rotation, output_mode="crop", sample_mode="bilinear", padding_mode="zeros", align_corners=None, p=0.5, nd=3, keys="*"
+    ):
         super().__init__(p, nd, keys)
         if self.nd > 3:
             raise NotImplementedError(f"Arbitrary rotation is only implemented for nd <= 3, got {nd}")
@@ -112,6 +119,7 @@ class RandomRotate(KeyedNdTransform):
             self.rotation[idx][0] = -self.rotation[idx][1]
 
         # set parameters for rotation
+        self.output_mode = output_mode
         self.sample_mode = sample_mode
         self.padding_mode = padding_mode
         self.align_corners = align_corners
@@ -129,11 +137,21 @@ class RandomRotate(KeyedNdTransform):
         if input.ndim < self.nd + 2:
             input = input.view(*[1] * (self.nd + 2 - input.ndim), *input.shape)
 
-        return rotate(
+        rotated = rotate(
             input,
             params["rot"],
             input.size(),
+            mode=self.output_mode,
             sample_mode=self.sample_mode,
             padding_mode=self.padding_mode,
             align_corners=self.align_corners,
-        ).view(*osh)
+        )
+
+        # there surely is a cleaner way to do this but I am too tired to write it properly
+        # TODO: do this better
+        for _ in range(max(len(osh) - rotated.ndim, 0)):
+            rotated = rotated.unsqueeze(0)
+        for _ in range(max(rotated.ndim - len(osh), 0)):
+            rotated = rotated.squeeze(0)
+
+        return rotated


### PR DESCRIPTION
Rotate now by default operates in square/cubic/etc space, but crops to original size. Options have been added for minpadding to contain all the information, or maxpadding to return a square/cubic/etc result. "nothing" option performs no additional adjustments, retaining previous behaviour.

## Description

This is a semi-breaking change for those using RandomRotate and expecting it to perform a regular affine transformation. Use mode='nothing' to do "nothing" adjustments to the input.

## Related Issue

[115](https://github.com/alexandrainst/torch-trandsforms/issues/115)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/ohjerm/torch-trandsforms/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/ohjerm/torch-trandsforms/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
